### PR TITLE
Fix containers clean up

### DIFF
--- a/containers.go
+++ b/containers.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"errors"
+	"log"
 	"time"
 
 	"github.com/gophercloud/gophercloud"
@@ -81,7 +83,12 @@ func ListContainers(client *gophercloud.ServiceClient, networks <-chan Resource)
 			}
 			return true, nil
 		}); err != nil {
-			panic(err)
+			var errForbidden gophercloud.ErrDefault403
+			if errors.As(err, &errForbidden) {
+				log.Printf("Skipping containers deletion. User not authorized to perform the requested action")
+			} else {
+				panic(err)
+			}
 		}
 	}()
 	return ch


### PR DESCRIPTION
In case the user does not have the role of swiftoperator the clean up of the containers would fail with forbidden and the prune script would not succeed. This commit avoid the issue by ignoring the forbidden error.