### PR TITLE
Delete containers recursively

### DIFF
--- a/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/accounts/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/accounts/doc.go
@@ -1,0 +1,28 @@
+/*
+Package accounts contains functionality for working with Object Storage
+account resources. An account is the top-level resource the object storage
+hierarchy: containers belong to accounts, objects belong to containers.
+
+Another way of thinking of an account is like a namespace for all your
+resources. It is synonymous with a project or tenant in other OpenStack
+services.
+
+Example to Get an Account
+
+	account, err := accounts.Get(objectStorageClient, nil).Extract()
+	fmt.Printf("%+v\n", account)
+
+Example to Update an Account
+
+	metadata := map[string]string{
+		"some": "metadata",
+	}
+
+	updateOpts := accounts.UpdateOpts{
+		Metadata: metadata,
+	}
+
+	updateResult, err := accounts.Update(objectStorageClient, updateOpts).Extract()
+	fmt.Printf("%+v\n", updateResult)
+*/
+package accounts

--- a/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/accounts/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/accounts/requests.go
@@ -1,0 +1,101 @@
+package accounts
+
+import "github.com/gophercloud/gophercloud"
+
+// GetOptsBuilder allows extensions to add additional headers to the Get
+// request.
+type GetOptsBuilder interface {
+	ToAccountGetMap() (map[string]string, error)
+}
+
+// GetOpts is a structure that contains parameters for getting an account's
+// metadata.
+type GetOpts struct {
+	Newest bool `h:"X-Newest"`
+}
+
+// ToAccountGetMap formats a GetOpts into a map[string]string of headers.
+func (opts GetOpts) ToAccountGetMap() (map[string]string, error) {
+	return gophercloud.BuildHeaders(opts)
+}
+
+// Get is a function that retrieves an account's metadata. To extract just the
+// custom metadata, call the ExtractMetadata method on the GetResult. To extract
+// all the headers that are returned (including the metadata), call the
+// Extract method on the GetResult.
+func Get(c *gophercloud.ServiceClient, opts GetOptsBuilder) (r GetResult) {
+	h := make(map[string]string)
+	if opts != nil {
+		headers, err := opts.ToAccountGetMap()
+		if err != nil {
+			r.Err = err
+			return
+		}
+		for k, v := range headers {
+			h[k] = v
+		}
+	}
+	resp, err := c.Head(getURL(c), &gophercloud.RequestOpts{
+		MoreHeaders: h,
+		OkCodes:     []int{204},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// UpdateOptsBuilder allows extensions to add additional headers to the Update
+// request.
+type UpdateOptsBuilder interface {
+	ToAccountUpdateMap() (map[string]string, error)
+}
+
+// UpdateOpts is a structure that contains parameters for updating, creating, or
+// deleting an account's metadata.
+type UpdateOpts struct {
+	Metadata          map[string]string
+	RemoveMetadata    []string
+	ContentType       *string `h:"Content-Type"`
+	DetectContentType *bool   `h:"X-Detect-Content-Type"`
+	TempURLKey        string  `h:"X-Account-Meta-Temp-URL-Key"`
+	TempURLKey2       string  `h:"X-Account-Meta-Temp-URL-Key-2"`
+}
+
+// ToAccountUpdateMap formats an UpdateOpts into a map[string]string of headers.
+func (opts UpdateOpts) ToAccountUpdateMap() (map[string]string, error) {
+	headers, err := gophercloud.BuildHeaders(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range opts.Metadata {
+		headers["X-Account-Meta-"+k] = v
+	}
+
+	for _, k := range opts.RemoveMetadata {
+		headers["X-Remove-Account-Meta-"+k] = "remove"
+	}
+
+	return headers, err
+}
+
+// Update is a function that creates, updates, or deletes an account's metadata.
+// To extract the headers returned, call the Extract method on the UpdateResult.
+func Update(c *gophercloud.ServiceClient, opts UpdateOptsBuilder) (r UpdateResult) {
+	h := make(map[string]string)
+	if opts != nil {
+		headers, err := opts.ToAccountUpdateMap()
+		if err != nil {
+			r.Err = err
+			return
+		}
+		for k, v := range headers {
+			h[k] = v
+		}
+	}
+	resp, err := c.Request("POST", updateURL(c), &gophercloud.RequestOpts{
+		MoreHeaders: h,
+		OkCodes:     []int{201, 202, 204},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/accounts/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/accounts/results.go
@@ -1,0 +1,112 @@
+package accounts
+
+import (
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+)
+
+// UpdateResult is returned from a call to the Update function.
+type UpdateResult struct {
+	gophercloud.HeaderResult
+}
+
+// UpdateHeader represents the headers returned in the response from an Update
+// request.
+type UpdateHeader struct {
+	ContentLength int64     `json:"Content-Length,string"`
+	ContentType   string    `json:"Content-Type"`
+	TransID       string    `json:"X-Trans-Id"`
+	Date          time.Time `json:"-"`
+}
+
+func (r *UpdateHeader) UnmarshalJSON(b []byte) error {
+	type tmp UpdateHeader
+	var s struct {
+		tmp
+		Date gophercloud.JSONRFC1123 `json:"Date"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+
+	*r = UpdateHeader(s.tmp)
+
+	r.Date = time.Time(s.Date)
+
+	return err
+}
+
+// Extract will return a struct of headers returned from a call to Get. To
+// obtain a map of headers, call the Extract method on the GetResult.
+func (r UpdateResult) Extract() (*UpdateHeader, error) {
+	var s UpdateHeader
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+// GetHeader represents the headers returned in the response from a Get request.
+type GetHeader struct {
+	BytesUsed      int64     `json:"X-Account-Bytes-Used,string"`
+	QuotaBytes     *int64    `json:"X-Account-Meta-Quota-Bytes,string"`
+	ContainerCount int64     `json:"X-Account-Container-Count,string"`
+	ContentLength  int64     `json:"Content-Length,string"`
+	ObjectCount    int64     `json:"X-Account-Object-Count,string"`
+	ContentType    string    `json:"Content-Type"`
+	TransID        string    `json:"X-Trans-Id"`
+	TempURLKey     string    `json:"X-Account-Meta-Temp-URL-Key"`
+	TempURLKey2    string    `json:"X-Account-Meta-Temp-URL-Key-2"`
+	Date           time.Time `json:"-"`
+}
+
+func (r *GetHeader) UnmarshalJSON(b []byte) error {
+	type tmp GetHeader
+	var s struct {
+		tmp
+		Date string `json:"Date"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+
+	*r = GetHeader(s.tmp)
+
+	if s.Date != "" {
+		r.Date, err = time.Parse(time.RFC1123, s.Date)
+	}
+
+	return err
+}
+
+// GetResult is returned from a call to the Get function.
+type GetResult struct {
+	gophercloud.HeaderResult
+}
+
+// Extract will return a struct of headers returned from a call to Get.
+func (r GetResult) Extract() (*GetHeader, error) {
+	var s GetHeader
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+// ExtractMetadata is a function that takes a GetResult (of type *http.Response)
+// and returns the custom metatdata associated with the account.
+func (r GetResult) ExtractMetadata() (map[string]string, error) {
+	if r.Err != nil {
+		return nil, r.Err
+	}
+
+	metadata := make(map[string]string)
+	for k, v := range r.Header {
+		if strings.HasPrefix(k, "X-Account-Meta-") {
+			key := strings.TrimPrefix(k, "X-Account-Meta-")
+			metadata[key] = v[0]
+		}
+	}
+	return metadata, nil
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/accounts/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/accounts/urls.go
@@ -1,0 +1,11 @@
+package accounts
+
+import "github.com/gophercloud/gophercloud"
+
+func getURL(c *gophercloud.ServiceClient) string {
+	return c.Endpoint
+}
+
+func updateURL(c *gophercloud.ServiceClient) string {
+	return getURL(c)
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/objects/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/objects/doc.go
@@ -1,0 +1,110 @@
+/*
+Package objects contains functionality for working with Object Storage
+object resources. An object is a resource that represents and contains data
+- such as documents, images, and so on. You can also store custom metadata
+with an object.
+
+Note: When referencing the Object Storage API docs, some of the API actions
+are listed under "containers" rather than "objects". This was an intentional
+design in Gophercloud to make some object actions feel more natural.
+
+Example to List Objects
+
+	containerName := "my_container"
+
+	listOpts := objects.ListOpts{
+		Full: true,
+	}
+
+	allPages, err := objects.List(objectStorageClient, containerName, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allObjects, err := objects.ExtractInfo(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, object := range allObjects {
+		fmt.Printf("%+v\n", object)
+	}
+
+Example to List Object Names
+
+	containerName := "my_container"
+
+	listOpts := objects.ListOpts{
+		Full: false,
+	}
+
+	allPages, err := objects.List(objectStorageClient, containerName, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allObjects, err := objects.ExtractNames(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, object := range allObjects {
+		fmt.Printf("%+v\n", object)
+	}
+
+Example to Create an Object
+
+	content := "some object content"
+	objectName := "my_object"
+	containerName := "my_container"
+
+	createOpts := objects.CreateOpts{
+		ContentType: "text/plain"
+		Content:     strings.NewReader(content),
+	}
+
+	object, err := objects.Create(objectStorageClient, containerName, objectName, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Copy an Object
+
+	objectName := "my_object"
+	containerName := "my_container"
+
+	copyOpts := objects.CopyOpts{
+		Destination: "/newContainer/newObject",
+	}
+
+	object, err := objects.Copy(objectStorageClient, containerName, objectName, copyOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete an Object
+
+	objectName := "my_object"
+	containerName := "my_container"
+
+	object, err := objects.Delete(objectStorageClient, containerName, objectName).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Download an Object's Data
+
+	objectName := "my_object"
+	containerName := "my_container"
+
+	object := objects.Download(objectStorageClient, containerName, objectName, nil)
+	if object.Err != nil {
+		panic(object.Err)
+	}
+	// if "ExtractContent" method is not called, the HTTP connection will remain consumed
+	content, err := object.ExtractContent()
+	if err != nil {
+		panic(err)
+	}
+*/
+package objects

--- a/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/objects/errors.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/objects/errors.go
@@ -1,0 +1,13 @@
+package objects
+
+import "github.com/gophercloud/gophercloud"
+
+// ErrWrongChecksum is the error when the checksum generated for an object
+// doesn't match the ETAG header.
+type ErrWrongChecksum struct {
+	gophercloud.BaseError
+}
+
+func (e ErrWrongChecksum) Error() string {
+	return "Local checksum does not match API ETag header"
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/objects/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/objects/requests.go
@@ -1,0 +1,669 @@
+package objects
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/md5"
+	"crypto/sha1"
+	"crypto/sha256"
+	"crypto/sha512"
+	"fmt"
+	"hash"
+	"io"
+	"io/ioutil"
+	"strings"
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/objectstorage/v1/accounts"
+	"github.com/gophercloud/gophercloud/openstack/objectstorage/v1/containers"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// ErrTempURLKeyNotFound is an error indicating that the Temp URL key was
+// neigther set nor resolved from a container or account metadata.
+type ErrTempURLKeyNotFound struct{ gophercloud.ErrMissingInput }
+
+func (e ErrTempURLKeyNotFound) Error() string {
+	return "Unable to obtain the Temp URL key."
+}
+
+// ErrTempURLDigestNotValid is an error indicating that the requested
+// cryptographic hash function is not supported.
+type ErrTempURLDigestNotValid struct {
+	gophercloud.ErrMissingInput
+	Digest string
+}
+
+func (e ErrTempURLDigestNotValid) Error() string {
+	return fmt.Sprintf("The requested %q digest is not supported.", e.Digest)
+}
+
+// ListOptsBuilder allows extensions to add additional parameters to the List
+// request.
+type ListOptsBuilder interface {
+	ToObjectListParams() (bool, string, error)
+}
+
+// ListOpts is a structure that holds parameters for listing objects.
+type ListOpts struct {
+	// Full is a true/false value that represents the amount of object information
+	// returned. If Full is set to true, then the content-type, number of bytes,
+	// hash date last modified, and name are returned. If set to false or not set,
+	// then only the object names are returned.
+	Full      bool
+	Limit     int    `q:"limit"`
+	Marker    string `q:"marker"`
+	EndMarker string `q:"end_marker"`
+	Format    string `q:"format"`
+	Prefix    string `q:"prefix"`
+	Delimiter string `q:"delimiter"`
+	Path      string `q:"path"`
+	Versions  bool   `q:"versions"`
+}
+
+// ToObjectListParams formats a ListOpts into a query string and boolean
+// representing whether to list complete information for each object.
+func (opts ListOpts) ToObjectListParams() (bool, string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return opts.Full, q.String(), err
+}
+
+// List is a function that retrieves all objects in a container. It also returns
+// the details for the container. To extract only the object information or names,
+// pass the ListResult response to the ExtractInfo or ExtractNames function,
+// respectively.
+func List(c *gophercloud.ServiceClient, containerName string, opts ListOptsBuilder) pagination.Pager {
+	url, err := listURL(c, containerName)
+	if err != nil {
+		return pagination.Pager{Err: err}
+	}
+
+	headers := map[string]string{"Accept": "text/plain", "Content-Type": "text/plain"}
+	if opts != nil {
+		full, query, err := opts.ToObjectListParams()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+
+		if full {
+			headers = map[string]string{"Accept": "application/json", "Content-Type": "application/json"}
+		}
+	}
+
+	pager := pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		p := ObjectPage{pagination.MarkerPageBase{PageResult: r}}
+		p.MarkerPageBase.Owner = p
+		return p
+	})
+	pager.Headers = headers
+	return pager
+}
+
+// DownloadOptsBuilder allows extensions to add additional parameters to the
+// Download request.
+type DownloadOptsBuilder interface {
+	ToObjectDownloadParams() (map[string]string, string, error)
+}
+
+// DownloadOpts is a structure that holds parameters for downloading an object.
+type DownloadOpts struct {
+	IfMatch           string    `h:"If-Match"`
+	IfModifiedSince   time.Time `h:"If-Modified-Since"`
+	IfNoneMatch       string    `h:"If-None-Match"`
+	IfUnmodifiedSince time.Time `h:"If-Unmodified-Since"`
+	Newest            bool      `h:"X-Newest"`
+	Range             string    `h:"Range"`
+	Expires           string    `q:"expires"`
+	MultipartManifest string    `q:"multipart-manifest"`
+	Signature         string    `q:"signature"`
+	ObjectVersionID   string    `q:"version-id"`
+}
+
+// ToObjectDownloadParams formats a DownloadOpts into a query string and map of
+// headers.
+func (opts DownloadOpts) ToObjectDownloadParams() (map[string]string, string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	if err != nil {
+		return nil, "", err
+	}
+	h, err := gophercloud.BuildHeaders(opts)
+	if err != nil {
+		return nil, q.String(), err
+	}
+	if !opts.IfModifiedSince.IsZero() {
+		h["If-Modified-Since"] = opts.IfModifiedSince.Format(time.RFC1123)
+	}
+	if !opts.IfUnmodifiedSince.IsZero() {
+		h["If-Unmodified-Since"] = opts.IfUnmodifiedSince.Format(time.RFC1123)
+	}
+	return h, q.String(), nil
+}
+
+// Download is a function that retrieves the content and metadata for an object.
+// To extract just the content, call the DownloadResult method ExtractContent,
+// after checking DownloadResult's Err field.
+func Download(c *gophercloud.ServiceClient, containerName, objectName string, opts DownloadOptsBuilder) (r DownloadResult) {
+	url, err := downloadURL(c, containerName, objectName)
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	h := make(map[string]string)
+	if opts != nil {
+		headers, query, err := opts.ToObjectDownloadParams()
+		if err != nil {
+			r.Err = err
+			return
+		}
+		for k, v := range headers {
+			h[k] = v
+		}
+		url += query
+	}
+
+	resp, err := c.Get(url, nil, &gophercloud.RequestOpts{
+		MoreHeaders:      h,
+		OkCodes:          []int{200, 206, 304},
+		KeepResponseBody: true,
+	})
+	r.Body, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToObjectCreateParams() (io.Reader, map[string]string, string, error)
+}
+
+// CreateOpts is a structure that holds parameters for creating an object.
+type CreateOpts struct {
+	Content            io.Reader
+	Metadata           map[string]string
+	NoETag             bool
+	CacheControl       string `h:"Cache-Control"`
+	ContentDisposition string `h:"Content-Disposition"`
+	ContentEncoding    string `h:"Content-Encoding"`
+	ContentLength      int64  `h:"Content-Length"`
+	ContentType        string `h:"Content-Type"`
+	CopyFrom           string `h:"X-Copy-From"`
+	DeleteAfter        int64  `h:"X-Delete-After"`
+	DeleteAt           int64  `h:"X-Delete-At"`
+	DetectContentType  string `h:"X-Detect-Content-Type"`
+	ETag               string `h:"ETag"`
+	IfNoneMatch        string `h:"If-None-Match"`
+	ObjectManifest     string `h:"X-Object-Manifest"`
+	TransferEncoding   string `h:"Transfer-Encoding"`
+	Expires            string `q:"expires"`
+	MultipartManifest  string `q:"multipart-manifest"`
+	Signature          string `q:"signature"`
+}
+
+// ToObjectCreateParams formats a CreateOpts into a query string and map of
+// headers.
+func (opts CreateOpts) ToObjectCreateParams() (io.Reader, map[string]string, string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	if err != nil {
+		return nil, nil, "", err
+	}
+	h, err := gophercloud.BuildHeaders(opts)
+	if err != nil {
+		return nil, nil, "", err
+	}
+
+	for k, v := range opts.Metadata {
+		h["X-Object-Meta-"+k] = v
+	}
+
+	if opts.NoETag {
+		delete(h, "etag")
+		return opts.Content, h, q.String(), nil
+	}
+
+	if h["ETag"] != "" {
+		return opts.Content, h, q.String(), nil
+	}
+
+	// When we're dealing with big files an io.ReadSeeker allows us to efficiently calculate
+	// the md5 sum. An io.Reader is only readable once which means we have to copy the entire
+	// file content into memory first.
+	readSeeker, isReadSeeker := opts.Content.(io.ReadSeeker)
+	if !isReadSeeker {
+		data, err := ioutil.ReadAll(opts.Content)
+		if err != nil {
+			return nil, nil, "", err
+		}
+		readSeeker = bytes.NewReader(data)
+	}
+
+	hash := md5.New()
+	// io.Copy into md5 is very efficient as it's done in small chunks.
+	if _, err := io.Copy(hash, readSeeker); err != nil {
+		return nil, nil, "", err
+	}
+	readSeeker.Seek(0, io.SeekStart)
+
+	h["ETag"] = fmt.Sprintf("%x", hash.Sum(nil))
+
+	return readSeeker, h, q.String(), nil
+}
+
+// Create is a function that creates a new object or replaces an existing
+// object. If the returned response's ETag header fails to match the local
+// checksum, the failed request will automatically be retried up to a maximum
+// of 3 times.
+func Create(c *gophercloud.ServiceClient, containerName, objectName string, opts CreateOptsBuilder) (r CreateResult) {
+	url, err := createURL(c, containerName, objectName)
+	if err != nil {
+		r.Err = err
+		return
+	}
+	h := make(map[string]string)
+	var b io.Reader
+	if opts != nil {
+		tmpB, headers, query, err := opts.ToObjectCreateParams()
+		if err != nil {
+			r.Err = err
+			return
+		}
+		for k, v := range headers {
+			h[k] = v
+		}
+		url += query
+		b = tmpB
+	}
+
+	resp, err := c.Put(url, b, nil, &gophercloud.RequestOpts{
+		MoreHeaders: h,
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// CopyOptsBuilder allows extensions to add additional parameters to the
+// Copy request.
+type CopyOptsBuilder interface {
+	ToObjectCopyMap() (map[string]string, error)
+}
+
+// CopyOptsQueryBuilder allows extensions to add additional query parameters to
+// the Copy request.
+type CopyOptsQueryBuilder interface {
+	ToObjectCopyQuery() (string, error)
+}
+
+// CopyOpts is a structure that holds parameters for copying one object to
+// another.
+type CopyOpts struct {
+	Metadata           map[string]string
+	ContentDisposition string `h:"Content-Disposition"`
+	ContentEncoding    string `h:"Content-Encoding"`
+	ContentType        string `h:"Content-Type"`
+	Destination        string `h:"Destination" required:"true"`
+	ObjectVersionID    string `q:"version-id"`
+}
+
+// ToObjectCopyMap formats a CopyOpts into a map of headers.
+func (opts CopyOpts) ToObjectCopyMap() (map[string]string, error) {
+	h, err := gophercloud.BuildHeaders(opts)
+	if err != nil {
+		return nil, err
+	}
+	for k, v := range opts.Metadata {
+		h["X-Object-Meta-"+k] = v
+	}
+	return h, nil
+}
+
+// ToObjectCopyQuery formats a CopyOpts into a query.
+func (opts CopyOpts) ToObjectCopyQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	if err != nil {
+		return "", err
+	}
+	return q.String(), nil
+}
+
+// Copy is a function that copies one object to another.
+func Copy(c *gophercloud.ServiceClient, containerName, objectName string, opts CopyOptsBuilder) (r CopyResult) {
+	url, err := copyURL(c, containerName, objectName)
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	h := make(map[string]string)
+	headers, err := opts.ToObjectCopyMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	for k, v := range headers {
+		h[k] = v
+	}
+
+	if opts, ok := opts.(CopyOptsQueryBuilder); ok {
+		query, err := opts.ToObjectCopyQuery()
+		if err != nil {
+			r.Err = err
+			return
+		}
+		url += query
+	}
+
+	resp, err := c.Request("COPY", url, &gophercloud.RequestOpts{
+		MoreHeaders: h,
+		OkCodes:     []int{201},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// DeleteOptsBuilder allows extensions to add additional parameters to the
+// Delete request.
+type DeleteOptsBuilder interface {
+	ToObjectDeleteQuery() (string, error)
+}
+
+// DeleteOpts is a structure that holds parameters for deleting an object.
+type DeleteOpts struct {
+	MultipartManifest string `q:"multipart-manifest"`
+	ObjectVersionID   string `q:"version-id"`
+}
+
+// ToObjectDeleteQuery formats a DeleteOpts into a query string.
+func (opts DeleteOpts) ToObjectDeleteQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// Delete is a function that deletes an object.
+func Delete(c *gophercloud.ServiceClient, containerName, objectName string, opts DeleteOptsBuilder) (r DeleteResult) {
+	url, err := deleteURL(c, containerName, objectName)
+	if err != nil {
+		r.Err = err
+		return
+	}
+	if opts != nil {
+		query, err := opts.ToObjectDeleteQuery()
+		if err != nil {
+			r.Err = err
+			return
+		}
+		url += query
+	}
+	resp, err := c.Delete(url, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// GetOptsBuilder allows extensions to add additional parameters to the
+// Get request.
+type GetOptsBuilder interface {
+	ToObjectGetParams() (map[string]string, string, error)
+}
+
+// GetOpts is a structure that holds parameters for getting an object's
+// metadata.
+type GetOpts struct {
+	Newest          bool   `h:"X-Newest"`
+	Expires         string `q:"expires"`
+	Signature       string `q:"signature"`
+	ObjectVersionID string `q:"version-id"`
+}
+
+// ToObjectGetParams formats a GetOpts into a query string and a map of headers.
+func (opts GetOpts) ToObjectGetParams() (map[string]string, string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	if err != nil {
+		return nil, "", err
+	}
+	h, err := gophercloud.BuildHeaders(opts)
+	if err != nil {
+		return nil, q.String(), err
+	}
+	return h, q.String(), nil
+}
+
+// Get is a function that retrieves the metadata of an object. To extract just
+// the custom metadata, pass the GetResult response to the ExtractMetadata
+// function.
+func Get(c *gophercloud.ServiceClient, containerName, objectName string, opts GetOptsBuilder) (r GetResult) {
+	url, err := getURL(c, containerName, objectName)
+	if err != nil {
+		r.Err = err
+		return
+	}
+	h := make(map[string]string)
+	if opts != nil {
+		headers, query, err := opts.ToObjectGetParams()
+		if err != nil {
+			r.Err = err
+			return
+		}
+		for k, v := range headers {
+			h[k] = v
+		}
+		url += query
+	}
+
+	resp, err := c.Head(url, &gophercloud.RequestOpts{
+		MoreHeaders: h,
+		OkCodes:     []int{200, 204},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
+type UpdateOptsBuilder interface {
+	ToObjectUpdateMap() (map[string]string, error)
+}
+
+// UpdateOpts is a structure that holds parameters for updating, creating, or
+// deleting an object's metadata.
+type UpdateOpts struct {
+	Metadata           map[string]string
+	RemoveMetadata     []string
+	ContentDisposition *string `h:"Content-Disposition"`
+	ContentEncoding    *string `h:"Content-Encoding"`
+	ContentType        *string `h:"Content-Type"`
+	DeleteAfter        *int64  `h:"X-Delete-After"`
+	DeleteAt           *int64  `h:"X-Delete-At"`
+	DetectContentType  *bool   `h:"X-Detect-Content-Type"`
+}
+
+// ToObjectUpdateMap formats a UpdateOpts into a map of headers.
+func (opts UpdateOpts) ToObjectUpdateMap() (map[string]string, error) {
+	h, err := gophercloud.BuildHeaders(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	for k, v := range opts.Metadata {
+		h["X-Object-Meta-"+k] = v
+	}
+
+	for _, k := range opts.RemoveMetadata {
+		h["X-Remove-Object-Meta-"+k] = "remove"
+	}
+	return h, nil
+}
+
+// Update is a function that creates, updates, or deletes an object's metadata.
+func Update(c *gophercloud.ServiceClient, containerName, objectName string, opts UpdateOptsBuilder) (r UpdateResult) {
+	url, err := updateURL(c, containerName, objectName)
+	if err != nil {
+		r.Err = err
+		return
+	}
+	h := make(map[string]string)
+	if opts != nil {
+		headers, err := opts.ToObjectUpdateMap()
+		if err != nil {
+			r.Err = err
+			return
+		}
+
+		for k, v := range headers {
+			h[k] = v
+		}
+	}
+	resp, err := c.Post(url, nil, nil, &gophercloud.RequestOpts{
+		MoreHeaders: h,
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// HTTPMethod represents an HTTP method string (e.g. "GET").
+type HTTPMethod string
+
+var (
+	// GET represents an HTTP "GET" method.
+	GET HTTPMethod = "GET"
+	// HEAD represents an HTTP "HEAD" method.
+	HEAD HTTPMethod = "HEAD"
+	// PUT represents an HTTP "PUT" method.
+	PUT HTTPMethod = "PUT"
+	// POST represents an HTTP "POST" method.
+	POST HTTPMethod = "POST"
+	// DELETE represents an HTTP "DELETE" method.
+	DELETE HTTPMethod = "DELETE"
+)
+
+// CreateTempURLOpts are options for creating a temporary URL for an object.
+type CreateTempURLOpts struct {
+	// (REQUIRED) Method is the HTTP method to allow for users of the temp URL.
+	// Valid values are "GET", "HEAD", "PUT", "POST" and "DELETE".
+	Method HTTPMethod
+
+	// (REQUIRED) TTL is the number of seconds the temp URL should be active.
+	TTL int
+
+	// (Optional) Split is the string on which to split the object URL. Since only
+	// the object path is used in the hash, the object URL needs to be parsed. If
+	// empty, the default OpenStack URL split point will be used ("/v1/").
+	Split string
+
+	// (Optional) Timestamp is the current timestamp used to calculate the Temp URL
+	// signature. If not specified, the current UNIX timestamp is used as the base
+	// timestamp.
+	Timestamp time.Time
+
+	// (Optional) TempURLKey overrides the Swift container or account Temp URL key.
+	// TempURLKey must correspond to a target container/account key, otherwise the
+	// generated link will be invalid. If not specified, the key is obtained from
+	// a Swift container or account.
+	TempURLKey string
+
+	// (Optional) Digest specifies the cryptographic hash function used to
+	// calculate the signature. Valid values include sha1, sha256, and
+	// sha512. If not specified, the default hash function is sha1.
+	Digest string
+}
+
+// CreateTempURL is a function for creating a temporary URL for an object. It
+// allows users to have "GET" or "POST" access to a particular tenant's object
+// for a limited amount of time.
+func CreateTempURL(c *gophercloud.ServiceClient, containerName, objectName string, opts CreateTempURLOpts) (string, error) {
+	url, err := getURL(c, containerName, objectName)
+	if err != nil {
+		return "", err
+	}
+
+	if opts.Split == "" {
+		opts.Split = "/v1/"
+	}
+
+	// Initialize time if it was not passed as opts
+	date := opts.Timestamp
+	if date.IsZero() {
+		date = time.Now()
+	}
+	duration := time.Duration(opts.TTL) * time.Second
+	// UNIX time is always UTC
+	expiry := date.Add(duration).Unix()
+
+	// Initialize the tempURLKey to calculate a signature
+	tempURLKey := opts.TempURLKey
+	if tempURLKey == "" {
+		// fallback to a container TempURL key
+		getHeader, err := containers.Get(c, containerName, nil).Extract()
+		if err != nil {
+			return "", err
+		}
+		tempURLKey = getHeader.TempURLKey
+		if tempURLKey == "" {
+			// fallback to an account TempURL key
+			getHeader, err := accounts.Get(c, nil).Extract()
+			if err != nil {
+				return "", err
+			}
+			tempURLKey = getHeader.TempURLKey
+		}
+		if tempURLKey == "" {
+			return "", ErrTempURLKeyNotFound{}
+		}
+	}
+
+	secretKey := []byte(tempURLKey)
+	splitPath := strings.Split(url, opts.Split)
+	baseURL, objectPath := splitPath[0], splitPath[1]
+	objectPath = opts.Split + objectPath
+	body := fmt.Sprintf("%s\n%d\n%s", opts.Method, expiry, objectPath)
+	var hash hash.Hash
+	switch opts.Digest {
+	case "", "sha1":
+		hash = hmac.New(sha1.New, secretKey)
+	case "sha256":
+		hash = hmac.New(sha256.New, secretKey)
+	case "sha512":
+		hash = hmac.New(sha512.New, secretKey)
+	default:
+		return "", ErrTempURLDigestNotValid{Digest: opts.Digest}
+	}
+	hash.Write([]byte(body))
+	hexsum := fmt.Sprintf("%x", hash.Sum(nil))
+	return fmt.Sprintf("%s%s?temp_url_sig=%s&temp_url_expires=%d", baseURL, objectPath, hexsum, expiry), nil
+}
+
+// BulkDelete is a function that bulk deletes objects.
+// In Swift, the maximum number of deletes per request is set by default to 10000.
+//
+// See:
+// * https://github.com/openstack/swift/blob/6d3d4197151f44bf28b51257c1a4c5d33411dcae/etc/proxy-server.conf-sample#L1029-L1034
+// * https://github.com/openstack/swift/blob/e8cecf7fcc1630ee83b08f9a73e1e59c07f8d372/swift/common/middleware/bulk.py#L309
+func BulkDelete(c *gophercloud.ServiceClient, container string, objects []string) (r BulkDeleteResult) {
+	err := containers.CheckContainerName(container)
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	var body bytes.Buffer
+	for i := range objects {
+		if objects[i] == "" {
+			r.Err = fmt.Errorf("object names must not be the empty string")
+			return
+		}
+		body.WriteString(container)
+		body.WriteRune('/')
+		body.WriteString(objects[i])
+		body.WriteRune('\n')
+	}
+
+	resp, err := c.Post(bulkDeleteURL(c), &body, &r.Body, &gophercloud.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Accept":       "application/json",
+			"Content-Type": "text/plain",
+		},
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/objects/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/objects/results.go
@@ -1,0 +1,552 @@
+package objects
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// Object is a structure that holds information related to a storage object.
+type Object struct {
+	// Bytes is the total number of bytes that comprise the object.
+	Bytes int64 `json:"bytes"`
+
+	// ContentType is the content type of the object.
+	ContentType string `json:"content_type"`
+
+	// Hash represents the MD5 checksum value of the object's content.
+	Hash string `json:"hash"`
+
+	// LastModified is the time the object was last modified.
+	LastModified time.Time `json:"-"`
+
+	// Name is the unique name for the object.
+	Name string `json:"name"`
+
+	// Subdir denotes if the result contains a subdir.
+	Subdir string `json:"subdir"`
+
+	// IsLatest indicates whether the object version is the latest one.
+	IsLatest bool `json:"is_latest"`
+
+	// VersionID contains a version ID of the object, when container
+	// versioning is enabled.
+	VersionID string `json:"version_id"`
+}
+
+func (r *Object) UnmarshalJSON(b []byte) error {
+	type tmp Object
+	var s *struct {
+		tmp
+		LastModified string `json:"last_modified"`
+	}
+
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+
+	*r = Object(s.tmp)
+
+	if s.LastModified != "" {
+		t, err := time.Parse(gophercloud.RFC3339MilliNoZ, s.LastModified)
+		if err != nil {
+			t, err = time.Parse(gophercloud.RFC3339Milli, s.LastModified)
+			if err != nil {
+				return err
+			}
+		}
+		r.LastModified = t
+	}
+
+	return nil
+}
+
+// ObjectPage is a single page of objects that is returned from a call to the
+// List function.
+type ObjectPage struct {
+	pagination.MarkerPageBase
+}
+
+// IsEmpty returns true if a ListResult contains no object names.
+func (r ObjectPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
+	names, err := ExtractNames(r)
+	return len(names) == 0, err
+}
+
+// LastMarker returns the last object name in a ListResult.
+func (r ObjectPage) LastMarker() (string, error) {
+	return extractLastMarker(r)
+}
+
+// ExtractInfo is a function that takes a page of objects and returns their
+// full information.
+func ExtractInfo(r pagination.Page) ([]Object, error) {
+	var s []Object
+	err := (r.(ObjectPage)).ExtractInto(&s)
+	return s, err
+}
+
+// ExtractNames is a function that takes a page of objects and returns only
+// their names.
+func ExtractNames(r pagination.Page) ([]string, error) {
+	casted := r.(ObjectPage)
+	ct := casted.Header.Get("Content-Type")
+	switch {
+	case strings.HasPrefix(ct, "application/json"):
+		parsed, err := ExtractInfo(r)
+		if err != nil {
+			return nil, err
+		}
+
+		names := make([]string, 0, len(parsed))
+		for _, object := range parsed {
+			if object.Subdir != "" {
+				names = append(names, object.Subdir)
+			} else {
+				names = append(names, object.Name)
+			}
+		}
+
+		return names, nil
+	case strings.HasPrefix(ct, "text/plain"):
+		names := make([]string, 0, 50)
+
+		body := string(r.(ObjectPage).Body.([]uint8))
+		for _, name := range strings.Split(body, "\n") {
+			if len(name) > 0 {
+				names = append(names, name)
+			}
+		}
+
+		return names, nil
+	case strings.HasPrefix(ct, "text/html"):
+		return []string{}, nil
+	default:
+		return nil, fmt.Errorf("Cannot extract names from response with content-type: [%s]", ct)
+	}
+}
+
+// DownloadHeader represents the headers returned in the response from a
+// Download request.
+type DownloadHeader struct {
+	AcceptRanges       string    `json:"Accept-Ranges"`
+	ContentDisposition string    `json:"Content-Disposition"`
+	ContentEncoding    string    `json:"Content-Encoding"`
+	ContentLength      int64     `json:"Content-Length,string"`
+	ContentType        string    `json:"Content-Type"`
+	Date               time.Time `json:"-"`
+	DeleteAt           time.Time `json:"-"`
+	ETag               string    `json:"Etag"`
+	LastModified       time.Time `json:"-"`
+	ObjectManifest     string    `json:"X-Object-Manifest"`
+	StaticLargeObject  bool      `json:"-"`
+	TransID            string    `json:"X-Trans-Id"`
+	ObjectVersionID    string    `json:"X-Object-Version-Id"`
+}
+
+func (r *DownloadHeader) UnmarshalJSON(b []byte) error {
+	type tmp DownloadHeader
+	var s struct {
+		tmp
+		Date              gophercloud.JSONRFC1123 `json:"Date"`
+		DeleteAt          gophercloud.JSONUnix    `json:"X-Delete-At"`
+		LastModified      gophercloud.JSONRFC1123 `json:"Last-Modified"`
+		StaticLargeObject interface{}             `json:"X-Static-Large-Object"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+
+	*r = DownloadHeader(s.tmp)
+
+	switch t := s.StaticLargeObject.(type) {
+	case string:
+		if t == "True" || t == "true" {
+			r.StaticLargeObject = true
+		}
+	case bool:
+		r.StaticLargeObject = t
+	}
+
+	r.Date = time.Time(s.Date)
+	r.DeleteAt = time.Time(s.DeleteAt)
+	r.LastModified = time.Time(s.LastModified)
+
+	return nil
+}
+
+// DownloadResult is a *http.Response that is returned from a call to the
+// Download function.
+type DownloadResult struct {
+	gophercloud.HeaderResult
+	Body io.ReadCloser
+}
+
+// Extract will return a struct of headers returned from a call to Download.
+func (r DownloadResult) Extract() (*DownloadHeader, error) {
+	var s DownloadHeader
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+// ExtractContent is a function that takes a DownloadResult's io.Reader body
+// and reads all available data into a slice of bytes. Please be aware that due
+// the nature of io.Reader is forward-only - meaning that it can only be read
+// once and not rewound. You can recreate a reader from the output of this
+// function by using bytes.NewReader(downloadBytes)
+func (r *DownloadResult) ExtractContent() ([]byte, error) {
+	if r.Err != nil {
+		return nil, r.Err
+	}
+	defer r.Body.Close()
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return nil, err
+	}
+	return body, nil
+}
+
+// GetHeader represents the headers returned in the response from a Get request.
+type GetHeader struct {
+	ContentDisposition string    `json:"Content-Disposition"`
+	ContentEncoding    string    `json:"Content-Encoding"`
+	ContentLength      int64     `json:"Content-Length,string"`
+	ContentType        string    `json:"Content-Type"`
+	Date               time.Time `json:"-"`
+	DeleteAt           time.Time `json:"-"`
+	ETag               string    `json:"Etag"`
+	LastModified       time.Time `json:"-"`
+	ObjectManifest     string    `json:"X-Object-Manifest"`
+	StaticLargeObject  bool      `json:"-"`
+	TransID            string    `json:"X-Trans-Id"`
+	ObjectVersionID    string    `json:"X-Object-Version-Id"`
+}
+
+func (r *GetHeader) UnmarshalJSON(b []byte) error {
+	type tmp GetHeader
+	var s struct {
+		tmp
+		Date              gophercloud.JSONRFC1123 `json:"Date"`
+		DeleteAt          gophercloud.JSONUnix    `json:"X-Delete-At"`
+		LastModified      gophercloud.JSONRFC1123 `json:"Last-Modified"`
+		StaticLargeObject interface{}             `json:"X-Static-Large-Object"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+
+	*r = GetHeader(s.tmp)
+
+	switch t := s.StaticLargeObject.(type) {
+	case string:
+		if t == "True" || t == "true" {
+			r.StaticLargeObject = true
+		}
+	case bool:
+		r.StaticLargeObject = t
+	}
+
+	r.Date = time.Time(s.Date)
+	r.DeleteAt = time.Time(s.DeleteAt)
+	r.LastModified = time.Time(s.LastModified)
+
+	return nil
+}
+
+// GetResult is a *http.Response that is returned from a call to the Get
+// function.
+type GetResult struct {
+	gophercloud.HeaderResult
+}
+
+// Extract will return a struct of headers returned from a call to Get.
+func (r GetResult) Extract() (*GetHeader, error) {
+	var s GetHeader
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+// ExtractMetadata is a function that takes a GetResult (of type *http.Response)
+// and returns the custom metadata associated with the object.
+func (r GetResult) ExtractMetadata() (map[string]string, error) {
+	if r.Err != nil {
+		return nil, r.Err
+	}
+	metadata := make(map[string]string)
+	for k, v := range r.Header {
+		if strings.HasPrefix(k, "X-Object-Meta-") {
+			key := strings.TrimPrefix(k, "X-Object-Meta-")
+			metadata[key] = v[0]
+		}
+	}
+	return metadata, nil
+}
+
+// CreateHeader represents the headers returned in the response from a
+// Create request.
+type CreateHeader struct {
+	ContentLength   int64     `json:"Content-Length,string"`
+	ContentType     string    `json:"Content-Type"`
+	Date            time.Time `json:"-"`
+	ETag            string    `json:"Etag"`
+	LastModified    time.Time `json:"-"`
+	TransID         string    `json:"X-Trans-Id"`
+	ObjectVersionID string    `json:"X-Object-Version-Id"`
+}
+
+func (r *CreateHeader) UnmarshalJSON(b []byte) error {
+	type tmp CreateHeader
+	var s struct {
+		tmp
+		Date         gophercloud.JSONRFC1123 `json:"Date"`
+		LastModified gophercloud.JSONRFC1123 `json:"Last-Modified"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+
+	*r = CreateHeader(s.tmp)
+
+	r.Date = time.Time(s.Date)
+	r.LastModified = time.Time(s.LastModified)
+
+	return nil
+}
+
+// CreateResult represents the result of a create operation.
+type CreateResult struct {
+	checksum string
+	gophercloud.HeaderResult
+}
+
+// Extract will return a struct of headers returned from a call to Create.
+func (r CreateResult) Extract() (*CreateHeader, error) {
+	//if r.Header.Get("ETag") != fmt.Sprintf("%x", localChecksum) {
+	//	return nil, ErrWrongChecksum{}
+	//}
+	var s CreateHeader
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+// UpdateHeader represents the headers returned in the response from a
+// Update request.
+type UpdateHeader struct {
+	ContentLength   int64     `json:"Content-Length,string"`
+	ContentType     string    `json:"Content-Type"`
+	Date            time.Time `json:"-"`
+	TransID         string    `json:"X-Trans-Id"`
+	ObjectVersionID string    `json:"X-Object-Version-Id"`
+}
+
+func (r *UpdateHeader) UnmarshalJSON(b []byte) error {
+	type tmp UpdateHeader
+	var s struct {
+		tmp
+		Date gophercloud.JSONRFC1123 `json:"Date"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+
+	*r = UpdateHeader(s.tmp)
+
+	r.Date = time.Time(s.Date)
+
+	return nil
+}
+
+// UpdateResult represents the result of an update operation.
+type UpdateResult struct {
+	gophercloud.HeaderResult
+}
+
+// Extract will return a struct of headers returned from a call to Update.
+func (r UpdateResult) Extract() (*UpdateHeader, error) {
+	var s UpdateHeader
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+// DeleteHeader represents the headers returned in the response from a
+// Delete request.
+type DeleteHeader struct {
+	ContentLength          int64     `json:"Content-Length,string"`
+	ContentType            string    `json:"Content-Type"`
+	Date                   time.Time `json:"-"`
+	TransID                string    `json:"X-Trans-Id"`
+	ObjectVersionID        string    `json:"X-Object-Version-Id"`
+	ObjectCurrentVersionID string    `json:"X-Object-Current-Version-Id"`
+}
+
+func (r *DeleteHeader) UnmarshalJSON(b []byte) error {
+	type tmp DeleteHeader
+	var s struct {
+		tmp
+		Date gophercloud.JSONRFC1123 `json:"Date"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+
+	*r = DeleteHeader(s.tmp)
+
+	r.Date = time.Time(s.Date)
+
+	return nil
+}
+
+// DeleteResult represents the result of a delete operation.
+type DeleteResult struct {
+	gophercloud.HeaderResult
+}
+
+// Extract will return a struct of headers returned from a call to Delete.
+func (r DeleteResult) Extract() (*DeleteHeader, error) {
+	var s DeleteHeader
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+// CopyHeader represents the headers returned in the response from a
+// Copy request.
+type CopyHeader struct {
+	ContentLength          int64     `json:"Content-Length,string"`
+	ContentType            string    `json:"Content-Type"`
+	CopiedFrom             string    `json:"X-Copied-From"`
+	CopiedFromLastModified time.Time `json:"-"`
+	Date                   time.Time `json:"-"`
+	ETag                   string    `json:"Etag"`
+	LastModified           time.Time `json:"-"`
+	TransID                string    `json:"X-Trans-Id"`
+	ObjectVersionID        string    `json:"X-Object-Version-Id"`
+}
+
+func (r *CopyHeader) UnmarshalJSON(b []byte) error {
+	type tmp CopyHeader
+	var s struct {
+		tmp
+		CopiedFromLastModified gophercloud.JSONRFC1123 `json:"X-Copied-From-Last-Modified"`
+		Date                   gophercloud.JSONRFC1123 `json:"Date"`
+		LastModified           gophercloud.JSONRFC1123 `json:"Last-Modified"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+
+	*r = CopyHeader(s.tmp)
+
+	r.Date = time.Time(s.Date)
+	r.CopiedFromLastModified = time.Time(s.CopiedFromLastModified)
+	r.LastModified = time.Time(s.LastModified)
+
+	return nil
+}
+
+// CopyResult represents the result of a copy operation.
+type CopyResult struct {
+	gophercloud.HeaderResult
+}
+
+// Extract will return a struct of headers returned from a call to Copy.
+func (r CopyResult) Extract() (*CopyHeader, error) {
+	var s CopyHeader
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+type BulkDeleteResponse struct {
+	ResponseStatus string     `json:"Response Status"`
+	ResponseBody   string     `json:"Response Body"`
+	Errors         [][]string `json:"Errors"`
+	NumberDeleted  int        `json:"Number Deleted"`
+	NumberNotFound int        `json:"Number Not Found"`
+}
+
+// BulkDeleteResult represents the result of a bulk delete operation. To extract
+// the response object from the HTTP response, call its Extract method.
+type BulkDeleteResult struct {
+	gophercloud.Result
+}
+
+// Extract will return a BulkDeleteResponse struct returned from a BulkDelete
+// call.
+func (r BulkDeleteResult) Extract() (*BulkDeleteResponse, error) {
+	var s BulkDeleteResponse
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+// extractLastMarker is a function that takes a page of objects and returns the
+// marker for the page. This can either be a subdir or the last object's name.
+func extractLastMarker(r pagination.Page) (string, error) {
+	casted := r.(ObjectPage)
+
+	// If a delimiter was requested, check if a subdir exists.
+	queryParams, err := url.ParseQuery(casted.URL.RawQuery)
+	if err != nil {
+		return "", err
+	}
+
+	var delimeter bool
+	if v, ok := queryParams["delimiter"]; ok && len(v) > 0 {
+		delimeter = true
+	}
+
+	ct := casted.Header.Get("Content-Type")
+	switch {
+	case strings.HasPrefix(ct, "application/json"):
+		parsed, err := ExtractInfo(r)
+		if err != nil {
+			return "", err
+		}
+
+		var lastObject Object
+		if len(parsed) > 0 {
+			lastObject = parsed[len(parsed)-1]
+		}
+
+		if !delimeter {
+			return lastObject.Name, nil
+		}
+
+		if lastObject.Name != "" {
+			return lastObject.Name, nil
+		}
+
+		return lastObject.Subdir, nil
+	case strings.HasPrefix(ct, "text/plain"):
+		names := make([]string, 0, 50)
+
+		body := string(r.(ObjectPage).Body.([]uint8))
+		for _, name := range strings.Split(body, "\n") {
+			if len(name) > 0 {
+				names = append(names, name)
+			}
+		}
+
+		return names[len(names)-1], err
+	case strings.HasPrefix(ct, "text/html"):
+		return "", nil
+	default:
+		return "", fmt.Errorf("Cannot extract names from response with content-type: [%s]", ct)
+	}
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/objects/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/objectstorage/v1/objects/urls.go
@@ -1,0 +1,44 @@
+package objects
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/objectstorage/v1/containers"
+)
+
+func listURL(c *gophercloud.ServiceClient, container string) (string, error) {
+	if err := containers.CheckContainerName(container); err != nil {
+		return "", err
+	}
+	return c.ServiceURL(container), nil
+}
+
+func copyURL(c *gophercloud.ServiceClient, container, object string) (string, error) {
+	if err := containers.CheckContainerName(container); err != nil {
+		return "", err
+	}
+	return c.ServiceURL(container, object), nil
+}
+
+func createURL(c *gophercloud.ServiceClient, container, object string) (string, error) {
+	return copyURL(c, container, object)
+}
+
+func getURL(c *gophercloud.ServiceClient, container, object string) (string, error) {
+	return copyURL(c, container, object)
+}
+
+func deleteURL(c *gophercloud.ServiceClient, container, object string) (string, error) {
+	return copyURL(c, container, object)
+}
+
+func downloadURL(c *gophercloud.ServiceClient, container, object string) (string, error) {
+	return copyURL(c, container, object)
+}
+
+func updateURL(c *gophercloud.ServiceClient, container, object string) (string, error) {
+	return copyURL(c, container, object)
+}
+
+func bulkDeleteURL(c *gophercloud.ServiceClient) string {
+	return c.Endpoint + "?bulk-delete=true"
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -25,7 +25,9 @@ github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/r
 github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/trunks
 github.com/gophercloud/gophercloud/openstack/networking/v2/networks
 github.com/gophercloud/gophercloud/openstack/networking/v2/ports
+github.com/gophercloud/gophercloud/openstack/objectstorage/v1/accounts
 github.com/gophercloud/gophercloud/openstack/objectstorage/v1/containers
+github.com/gophercloud/gophercloud/openstack/objectstorage/v1/objects
 github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/shares
 github.com/gophercloud/gophercloud/openstack/sharedfilesystems/v2/snapshots
 github.com/gophercloud/gophercloud/openstack/utils


### PR DESCRIPTION
Prune no longer fails on non-empty containers. It now delete all objects before trying to delete the container. This patch borrows code from the openshift installer's destroy module.