### PR TITLE
OSASINFRA-3279: Skip deletion of ovn metadata Port

### DIFF
--- a/ports.go
+++ b/ports.go
@@ -54,6 +54,9 @@ func ListPorts(client *gophercloud.ServiceClient) <-chan Resource {
 		if err := ports.List(client, nil).EachPage(func(page pagination.Page) (bool, error) {
 			resources, err := ports.ExtractPorts(page)
 			for i := range resources {
+				if strings.Contains(resources[i].DeviceID, "ovnmeta") {
+					continue
+				}
 				ch <- Port{
 					resource: &resources[i],
 					client:   client,


### PR DESCRIPTION
the OVN metadata Port is created when the network is created and should not be deleted. Let's skip the deletion of it in the Prune script.