### PR TITLE
volumes: remove attachments if needed

### DIFF
--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/attachments/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/attachments/doc.go
@@ -1,0 +1,86 @@
+/*
+Package attachments provides access to OpenStack Block Storage Attachment
+API's. Use of this package requires Cinder version 3.27 at a minimum.
+
+For more information, see:
+https://docs.openstack.org/api-ref/block-storage/v3/index.html#attachments
+
+Example to List Attachments
+
+	listOpts := &attachments.ListOpts{
+		InstanceID: "uuid",
+	}
+
+	client.Microversion = "3.27"
+	allPages, err := attachments.List(client, listOpts).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allAttachments, err := attachments.ExtractAttachments(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, attachment := range allAttachments {
+		fmt.Println(attachment)
+	}
+
+Example to Create Attachment
+
+	createOpts := &attachments.CreateOpts{
+		InstanceUUID: "uuid",
+		VolumeUUID: "uuid"
+	}
+
+	client.Microversion = "3.27"
+	attachment, err := attachments.Create(client, createOpts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(attachment)
+
+Example to Get Attachment
+
+	client.Microversion = "3.27"
+	attachment, err := attachments.Get(client, "uuid").Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(attachment)
+
+Example to Update Attachment
+
+	opts := &attachments.UpdateOpts{
+		Connector: map[string]interface{}{
+			"mode": "ro",
+		}
+	}
+
+	client.Microversion = "3.27"
+	attachment, err := attachments.Update(client, "uuid", opts).Extract()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(attachment)
+
+Example to Complete Attachment
+
+	client.Microversion = "3.44"
+	err := attachments.Complete(client, "uuid").ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+
+Example to Delete Attachment
+
+	client.Microversion = "3.27"
+	err := attachments.Delete(client, "uuid").ExtractErr()
+	if err != nil {
+		panic(err)
+	}
+*/
+package attachments

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/attachments/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/attachments/requests.go
@@ -1,0 +1,180 @@
+package attachments
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToAttachmentCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts contains options for creating a Volume attachment. This object is
+// passed to the Create function. For more information about these parameters,
+// see the Attachment object.
+type CreateOpts struct {
+	// VolumeUUID is the UUID of the Cinder volume to create the attachment
+	// record for.
+	VolumeUUID string `json:"volume_uuid"`
+	// InstanceUUID is the ID of the Server to create the attachment for.
+	// When attaching to a Nova Server this is the Nova Server (Instance)
+	// UUID.
+	InstanceUUID string `json:"instance_uuid"`
+	// Connector is an optional map containing all of the needed atachment
+	// information for exmaple initiator IQN, etc.
+	Connector map[string]interface{} `json:"connector,omitempty"`
+	// Mode is an attachment mode. Acceptable values are read-only ('ro')
+	// and read-and-write ('rw'). Available only since 3.54 microversion.
+	// For APIs from 3.27 till 3.53 use Connector["mode"] = "rw|ro".
+	Mode string `json:"mode,omitempty"`
+}
+
+// ToAttachmentCreateMap assembles a request body based on the contents of a
+// CreateOpts.
+func (opts CreateOpts) ToAttachmentCreateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "attachment")
+}
+
+// Create will create a new Attachment based on the values in CreateOpts. To
+// extract the Attachment object from the response, call the Extract method on
+// the CreateResult.
+func Create(client *gophercloud.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToAttachmentCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Post(createURL(client), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200, 202},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// Delete will delete the existing Attachment with the provided ID.
+func Delete(client *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	resp, err := client.Delete(deleteURL(client, id), &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// Get retrieves the Attachment with the provided ID. To extract the Attachment
+// object from the response, call the Extract method on the GetResult.
+func Get(client *gophercloud.ServiceClient, id string) (r GetResult) {
+	resp, err := client.Get(getURL(client, id), &r.Body, nil)
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// ListOptsBuilder allows extensions to add additional parameters to the List
+// request.
+type ListOptsBuilder interface {
+	ToAttachmentListQuery() (string, error)
+}
+
+// ListOpts holds options for listing Attachments. It is passed to the attachments.List
+// function.
+type ListOpts struct {
+	// AllTenants will retrieve attachments of all tenants/projects.
+	AllTenants bool `q:"all_tenants"`
+
+	// Status will filter by the specified status.
+	Status string `q:"status"`
+
+	// ProjectID will filter by a specific tenant/project ID.
+	ProjectID string `q:"project_id"`
+
+	// VolumeID will filter by a specific volume ID.
+	VolumeID string `q:"volume_id"`
+
+	// InstanceID will filter by a specific instance ID.
+	InstanceID string `q:"instance_id"`
+
+	// Comma-separated list of sort keys and optional sort directions in the
+	// form of <key>[:<direction>].
+	Sort string `q:"sort"`
+
+	// Requests a page size of items.
+	Limit int `q:"limit"`
+
+	// Used in conjunction with limit to return a slice of items.
+	Offset int `q:"offset"`
+
+	// The ID of the last-seen item.
+	Marker string `q:"marker"`
+}
+
+// ToAttachmentListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToAttachmentListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List returns Attachments optionally limited by the conditions provided in
+// ListOpts.
+func List(client *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(client)
+	if opts != nil {
+		query, err := opts.ToAttachmentListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return AttachmentPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
+type UpdateOptsBuilder interface {
+	ToAttachmentUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts contain options for updating an existing Attachment.
+// This is used to finalize an attachment that was created without a
+// connector (reserve).
+type UpdateOpts struct {
+	Connector map[string]interface{} `json:"connector"`
+}
+
+// ToAttachmentUpdateMap assembles a request body based on the contents of an
+// UpdateOpts.
+func (opts UpdateOpts) ToAttachmentUpdateMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "attachment")
+}
+
+// Update will update the Attachment with provided information. To extract the
+// updated Attachment from the response, call the Extract method on the
+// UpdateResult.
+func Update(client *gophercloud.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToAttachmentUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	resp, err := client.Put(updateURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}
+
+// Complete will complete an attachment for a cinder volume.
+// Available starting in the 3.44 microversion.
+func Complete(client *gophercloud.ServiceClient, id string) (r CompleteResult) {
+	b := map[string]interface{}{
+		"os-complete": nil,
+	}
+	resp, err := client.Post(completeURL(client, id), b, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{204},
+	})
+	_, r.Header, r.Err = gophercloud.ParseResponse(resp, err)
+	return
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/attachments/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/attachments/results.go
@@ -1,0 +1,124 @@
+// Package attachments provides access to OpenStack Block Storage Attachment
+// API's. Use of this package requires Cinder version 3.27 at a minimum.
+package attachments
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// Attachment contains all the information associated with an OpenStack
+// Attachment.
+type Attachment struct {
+	// ID is the Unique identifier for the attachment.
+	ID string `json:"id"`
+	// VolumeID is the UUID of the Volume associated with this attachment.
+	VolumeID string `json:"volume_id"`
+	// Instance is the Instance/Server UUID associated with this attachment.
+	Instance string `json:"instance"`
+	// AttachedAt is the time the attachment was created.
+	AttachedAt time.Time `json:"-"`
+	// DetachedAt is the time the attachment was detached.
+	DetachedAt time.Time `json:"-"`
+	// Status is the current attach status.
+	Status string `json:"status"`
+	// AttachMode includes things like Read Only etc.
+	AttachMode string `json:"attach_mode"`
+	// ConnectionInfo is the required info for a node to make a connection
+	// provided by the driver.
+	ConnectionInfo map[string]interface{} `json:"connection_info"`
+}
+
+// UnmarshalJSON is our unmarshalling helper
+func (r *Attachment) UnmarshalJSON(b []byte) error {
+	type tmp Attachment
+	var s struct {
+		tmp
+		AttachedAt gophercloud.JSONRFC3339MilliNoZ `json:"attached_at"`
+		DetachedAt gophercloud.JSONRFC3339MilliNoZ `json:"detached_at"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	*r = Attachment(s.tmp)
+
+	r.AttachedAt = time.Time(s.AttachedAt)
+	r.DetachedAt = time.Time(s.DetachedAt)
+
+	return err
+}
+
+// AttachmentPage is a pagination.pager that is returned from a call to the List
+// function.
+type AttachmentPage struct {
+	pagination.LinkedPageBase
+}
+
+// IsEmpty returns true if a ListResult contains no Attachments.
+func (r AttachmentPage) IsEmpty() (bool, error) {
+	if r.StatusCode == 204 {
+		return true, nil
+	}
+
+	attachments, err := ExtractAttachments(r)
+	return len(attachments) == 0, err
+}
+
+// ExtractAttachments extracts and returns Attachments. It is used while
+// iterating over a attachment.List call.
+func ExtractAttachments(r pagination.Page) ([]Attachment, error) {
+	var s []Attachment
+	err := ExtractAttachmentsInto(r, &s)
+	return s, err
+}
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract will get the Attachment object out of the commonResult object.
+func (r commonResult) Extract() (*Attachment, error) {
+	var s Attachment
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+// ExtractInto converts our response data into a attachment struct.
+func (r commonResult) ExtractInto(a interface{}) error {
+	return r.Result.ExtractIntoStructPtr(a, "attachment")
+}
+
+// ExtractAttachmentsInto similar to ExtractInto but operates on a List of
+// attachments.
+func ExtractAttachmentsInto(r pagination.Page, a interface{}) error {
+	return r.(AttachmentPage).Result.ExtractIntoSlicePtr(a, "attachments")
+}
+
+// CreateResult contains the response body and error from a Create request.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult contains the response body and error from a Get request.
+type GetResult struct {
+	commonResult
+}
+
+// UpdateResult contains the response body and error from an Update request.
+type UpdateResult struct {
+	commonResult
+}
+
+// DeleteResult contains the response body and error from a Delete request.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+// CompleteResult contains the response body and error from a Complete request.
+type CompleteResult struct {
+	gophercloud.ErrResult
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/attachments/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/attachments/urls.go
@@ -1,0 +1,27 @@
+package attachments
+
+import "github.com/gophercloud/gophercloud"
+
+func createURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("attachments")
+}
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("attachments", "detail")
+}
+
+func getURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("attachments", id)
+}
+
+func updateURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("attachments", id)
+}
+
+func deleteURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("attachments", id)
+}
+
+func completeURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("attachments", id, "action")
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/attachments/util.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/attachments/util.go
@@ -1,0 +1,22 @@
+package attachments
+
+import (
+	"github.com/gophercloud/gophercloud"
+)
+
+// WaitForStatus will continually poll the resource, checking for a particular
+// status. It will do this for the amount of seconds defined.
+func WaitForStatus(c *gophercloud.ServiceClient, id, status string, secs int) error {
+	return gophercloud.WaitFor(secs, func() (bool, error) {
+		current, err := Get(c, id).Extract()
+		if err != nil {
+			return false, err
+		}
+
+		if current.Status == status {
+			return true, nil
+		}
+
+		return false, nil
+	})
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2,6 +2,7 @@
 ## explicit; go 1.14
 github.com/gophercloud/gophercloud
 github.com/gophercloud/gophercloud/openstack
+github.com/gophercloud/gophercloud/openstack/blockstorage/v3/attachments
 github.com/gophercloud/gophercloud/openstack/blockstorage/v3/snapshots
 github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes
 github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/keypairs

--- a/volumes.go
+++ b/volumes.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/attachments"
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes"
 	"github.com/gophercloud/gophercloud/pagination"
 )
@@ -18,6 +19,15 @@ func (s Volume) CreatedAt() time.Time {
 }
 
 func (s Volume) Delete() error {
+	if s.resource.Attachments != nil {
+		s.client.Microversion = "3.44"
+		for _, attachment := range s.resource.Attachments {
+			err := attachments.Delete(s.client, attachment.AttachmentID).ExtractErr()
+			if err != nil {
+				return err
+			}
+		}
+	}
 	return volumes.Delete(s.client, s.resource.ID, volumes.DeleteOpts{Cascade: true}).ExtractErr()
 }
 


### PR DESCRIPTION
Before removing a volume, let's try to remove its attachments
(if any) and return an error if that operation failed.

Note that this operation requires a microversion >= 3.27.
