### PR TITLE
Fix deletion of routers

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,11 +4,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"golang.org/x/term"
 	"log"
 	"os"
 	"strings"
 	"time"
+
+	"golang.org/x/term"
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/utils/openstack/clientconfig"
@@ -178,15 +179,15 @@ func main() {
 				resources <- res
 			}
 
-			for res := range Filter(ListRouters(networkClient), NameIsNot[Resource]("dualstack")) {
-				resources <- res
-			}
-
 			for res := range ListTrunks(networkClient) {
 				resources <- res
 			}
 
 			for res := range ListPorts(networkClient) {
+				resources <- res
+			}
+
+			for res := range Filter(ListRouters(networkClient), NameIsNot[Resource]("dualstack")) {
 				resources <- res
 			}
 

--- a/ports.go
+++ b/ports.go
@@ -54,6 +54,12 @@ func ListPorts(client *gophercloud.ServiceClient) <-chan Resource {
 		if err := ports.List(client, nil).EachPage(func(page pagination.Page) (bool, error) {
 			resources, err := ports.ExtractPorts(page)
 			for i := range resources {
+				// These ports can't be deleted by the port API, they'll be deleted by the router API.
+				if strings.Contains(resources[i].DeviceOwner, "network:router") {
+					continue
+				}
+				// These ports are created by the OVN metadata and can't be deleted by the port API
+				// and are deleted when the network is deleted.
 				if strings.Contains(resources[i].DeviceID, "ovnmeta") {
 					continue
 				}

--- a/routers.go
+++ b/routers.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers"
-	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
 	"github.com/gophercloud/gophercloud/pagination"
 )
 
@@ -20,11 +19,6 @@ func (s Router) CreatedAt() time.Time {
 }
 
 func (s Router) Delete() error {
-	for _, subnet := range s.resource.subnets {
-		if _, err := routers.RemoveInterface(s.client, s.resource.ID, routers.RemoveInterfaceOpts{SubnetID: subnet}).Extract(); err != nil {
-			return err
-		}
-	}
 	return routers.Delete(s.client, s.resource.ID).ExtractErr()
 }
 
@@ -74,20 +68,6 @@ func ListRouters(client *gophercloud.ServiceClient) <-chan Resource {
 			}
 
 			for i := range routerPage.Routers {
-				if err := ports.List(client, ports.ListOpts{DeviceID: routerPage.Routers[i].ID}).EachPage(func(page pagination.Page) (bool, error) {
-					portList, err := ports.ExtractPorts(page)
-					if err != nil {
-						return false, err
-					}
-					for _, port := range portList {
-						for j := range port.FixedIPs {
-							routerPage.Routers[i].subnets = append(routerPage.Routers[i].subnets, port.FixedIPs[j].SubnetID)
-						}
-					}
-					return true, nil
-				}); err != nil {
-					return true, err
-				}
 				ch <- Router{
 					resource: &routerPage.Routers[i],
 					client:   client,


### PR DESCRIPTION
If a router has an external gateway, we'll not try to delete the gateway
port, which will be done later once the router is being deleted.
The subnets don't need to be detached from the router anymore, we remove a filtered list of ports first, then we remove the routers.

Fixes: #18