### PR TITLE
Stop trying to remove all ports connected to the a router

### DIFF
--- a/routers.go
+++ b/routers.go
@@ -74,7 +74,7 @@ func ListRouters(client *gophercloud.ServiceClient) <-chan Resource {
 			}
 
 			for i := range routerPage.Routers {
-				if err := ports.List(client, ports.ListOpts{DeviceID: routerPage.Routers[i].ID}).EachPage(func(page pagination.Page) (bool, error) {
+				if err := ports.List(client, ports.ListOpts{DeviceID: routerPage.Routers[i].ID, DeviceOwner: "network:router_interface"}).EachPage(func(page pagination.Page) (bool, error) {
 					portList, err := ports.ExtractPorts(page)
 					if err != nil {
 						return false, err


### PR DESCRIPTION
We should only trying to remove the ports from the router that has device owner network:router_interface, the external gateway ports will be removed automatically when the router is deleted.