### PR TITLE
Avoid clean up of network ports

### DIFF
--- a/ports.go
+++ b/ports.go
@@ -54,7 +54,7 @@ func ListPorts(client *gophercloud.ServiceClient) <-chan Resource {
 		if err := ports.List(client, nil).EachPage(func(page pagination.Page) (bool, error) {
 			resources, err := ports.ExtractPorts(page)
 			for i := range resources {
-				if strings.Contains(resources[i].DeviceID, "ovnmeta") {
+				if isOpenStackManaged(resources[i]) {
 					continue
 				}
 				ch <- Port{
@@ -68,4 +68,14 @@ func ListPorts(client *gophercloud.ServiceClient) <-chan Resource {
 		}
 	}()
 	return ch
+}
+
+func isOpenStackManaged(port ports.Port) bool {
+	deviceOwnerPrefixes := []string{"network:", "neutron:"}
+	for _, prefix := range deviceOwnerPrefixes {
+		if strings.Contains(port.DeviceOwner, prefix) {
+			return true
+		}
+	}
+	return strings.Contains(port.DeviceID, "ovnmeta")
 }


### PR DESCRIPTION
There were cases that ports that had device_owner like network:router_interface or network:router_gateway were attempted to clean up, those ports are automatically cleaned up when the subnet is removed to the router interface or the network is unset from external gateway. Any port that has device_owner starting with network should not be cleaned up, those are internal neutron generated resources.