### PR TITLE
OSASINFRA-3450: Forcing the share deletion

### DIFF
--- a/shares.go
+++ b/shares.go
@@ -23,7 +23,7 @@ func (s Share) Delete(ctx context.Context) error {
 	if err := deleteShareSnapshots(ctx, s.client, s.ID()); err != nil {
 		return err
 	}
-	return shares.Delete(ctx, s.client, s.resource.ID).ExtractErr()
+	return shares.ForceDelete(ctx, s.client, s.resource.ID).ExtractErr()
 }
 
 func (s Share) Type() string {


### PR DESCRIPTION
This is a workaround for [OSASINFRA-3450](https://issues.redhat.com/browse/OSASINFRA-3450): "CI: Manila shares randomly in error when deleting" by forcing the share deletion. 

A bug yielded from this issue was opened at [Bug #2065705 “CephFS driver fails to delete non-existent shares” : Bugs : OpenStack Shared File Systems Service (Manila)](https://bugs.launchpad.net/manila/+bug/2065705) 