### PR TITLE
networks: skip RHOSO-created networks

### DIFF
--- a/main.go
+++ b/main.go
@@ -203,7 +203,7 @@ func main() {
 				resources <- res
 			}
 
-			for res := range Filter(ListNetworks(ctx, networkClient), NameDoesNotContain[Resource]("hostonly", "external", "sahara-access", "mellanox", "intel", "public", "provider")) {
+			for res := range Filter(ListNetworks(ctx, networkClient), NameDoesNotContain[Resource]("lb-mgmt-net", "octavia-provider-net", "hostonly", "external", "sahara-access", "mellanox", "intel", "public", "provider")) {
 				resources <- res
 			}
 


### PR DESCRIPTION
In RHOSO 18, we have 2 networks created for Octavia:

* `lb-mgmt-net`

https://github.com/openstack-k8s-operators/octavia-operator/blob/79b9029e5255de3b9dbf0f20a7b483248c768556/pkg/octavia/network_consts.go#L25

* `octavia-provider-net`

https://github.com/openstack-k8s-operators/octavia-operator/blob/79b9029e5255de3b9dbf0f20a7b483248c768556/pkg/octavia/network_consts.go#L75

Let's skip the deletion of these networks.
