### PR TITLE
feat: add resource type filtering support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,33 @@ Configure the resoruce TTL with `--resource-ttl=<duration>` where `<duration>` i
 export OS_CLOUD=<clouds.yaml entry>
 ./prune --no-dry-run --resource-ttl=5h
 ```
+
+## Resource filtering
+
+Filter resources by type:
+
+```shell
+# Only process servers and volumes
+./prune --include=servers,volumes
+
+# Process everything except images and networks
+./prune --exclude=images,networks
+
+Available resource types:
+
+| Resource type    | Service    | Description                        |
+|------------------|------------|------------------------------------|
+| `appcreds`       | `keystone` | Application credentials            |
+| `containers`     | `swift`    | Object storage containers          |
+| `floatingips`    | `neutron`  | Public IP addresses               |
+| `images`         | `glance`   | Virtual machine images            |
+| `loadbalancers`  | `octavia`  | Load balancers                    |
+| `networks`       | `neutron`  | Virtual networks                  |
+| `ports`          | `neutron`  | Virtual network ports             |
+| `routers`        | `neutron`  | Virtual routers                   |
+| `securitygroups` | `neutron`  | Security groups                   |
+| `servers`        | `nova`     | Virtual machines                  |
+| `shares`         | `manila`   | Shared file systems               |
+| `trunks`         | `neutron`  | Virtual network trunks            |
+| `volumes`        | `cinder`   | Block storage volumes             |
+| `volumesnapshots`| `cinder`   | Block storage volume snapshots    |


### PR DESCRIPTION
Add two new CLI options to filter which resources to process:
- `--include`: only process specified resource types
- `--exclude`: process all resource types except those specified

The resource types are validated against a predefined list to prevent
typos and invalid inputs. Resource types cannot be both included and
excluded simultaneously.

Available resource types:
- floatingips (Neutron)
- loadbalancers (Octavia)
- servers (Nova)
- routers (Neutron)
- trunks (Neutron)
- ports (Neutron)
- networks (Neutron)
- volumesnapshots (Cinder)
- volumes (Cinder)
- securitygroups (Neutron)
- shares (Manila)
- appcreds (Keystone)
- containers (Swift)
- images (Glance)

Example usage:
```
./prune --include=servers,volumes
./prune --exclude=images,networks
```
